### PR TITLE
Handle upload directory with spaces in calling htmldoc

### DIFF
--- a/MediaWiki/PdfBook/PdfBook.hooks.php
+++ b/MediaWiki/PdfBook/PdfBook.hooks.php
@@ -141,8 +141,8 @@ class PdfBookHooks {
 						. " --bodyfont $font --fontsize $size --fontspacing $ls --linkstyle plain --linkcolor $linkcol"
 						. "$toc --no-title --numbered --charset $charset $options $layout $width";
 					$cmd = $format == 'htmltoc'
-						? "htmldoc -t html --format html $cmd $file"
-						: "htmldoc -t pdf --format pdf14 $cmd $file";
+						? "htmldoc -t html --format html $cmd \"$file\" "
+						: "htmldoc -t pdf --format pdf14 $cmd \"$file\" ";
 
 					// Execute the command outputting to the cache file
 					putenv( "HTMLDOC_NOCGI=1" );


### PR DESCRIPTION
If the upload directory contains spaces (as it might e.g. on a 'standard' setup on windows), the file parameter when calling htmldoc needs to be enclosed in double quotes.
Tested on windows only